### PR TITLE
灯箱特效模式下，点击“编辑”按钮后删除lightbox属性值

### DIFF
--- a/js/grapheditor/EditorUi.js
+++ b/js/grapheditor/EditorUi.js
@@ -3181,7 +3181,10 @@ EditorUi.prototype.initCanvas = function()
 			addButton(
 				mxUtils.bind(
 					this,
-					function (evt) {
+					async function (evt) {
+						window.siyuan.attrs['custom-lightbox'] = null;
+                		await window.siyuan.setBlockAttrs();
+
 						const url = new URL(window.location);
 						url.searchParams.delete('lightbox');
 						window.location.href = url.href;


### PR DESCRIPTION
删除lightbox值完成之后，再刷新页面，否则menu中的“灯箱效果”仍然是选中效果。